### PR TITLE
feat: handle email feature flag

### DIFF
--- a/.do/app.template.yaml
+++ b/.do/app.template.yaml
@@ -56,6 +56,8 @@ services:
         value: "${RESEND_EMAIL_SENDER}"
       - key: "BASE_URL"
         value: "__APP_URL_BIND__"
+      - key: "ENABLE_EMAIL_INTEGRATION"
+        value: "false"
 
 databases:
   - name: ${DB_NAME}

--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -67,6 +67,8 @@ spec:
           value: ""
         - key: "BASE_URL"
           value: ""
+        - key: "ENABLE_EMAIL_INTEGRATION"
+          value: "false"
 
   # Configuration for databases
   databases:

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ npm run dev
 
 ## Resend setup
 
-Resend is required for using the app beyond the landing page. The configuration has two values, a Resend API key and a sender address. To configure them, create an account or login and follow these steps:
+The email feature is disabled by default, but you can still use the application without receiving emails. Keep in mind that some flows, like forgot password or login with a magic link, will not work. To enable it, set the environment variable `ENABLE_EMAIL_INTEGRATION` to 'true'.
+
+The Resend configuration has two values, a Resend API key and a sender address. To configure them, create an account or login and follow these steps:
 
 **Configure sender address**
 

--- a/application/env-example
+++ b/application/env-example
@@ -29,7 +29,7 @@ RESEND_API_KEY=your-resend-api-key # API key from Resend
 RESEND_EMAIL_SENDER=your-email-sender-address # Email sender address, your-address@your-domain.{com/net/etc}
 # Development flag to disable email verification for local development
 # Set to true to skip email verification and allow immediate login after signup
-# DISABLE_EMAIL_VERIFICATION=true
+ENABLE_EMAIL_INTEGRATION=false
 
 # (Optional) Additional configuration
 

--- a/application/src/app/api/auth/magic-link/route.test.ts
+++ b/application/src/app/api/auth/magic-link/route.test.ts
@@ -1,3 +1,4 @@
+import { HTTP_STATUS } from 'lib/api/http';
 import { POST } from './route';
 import { NextRequest } from 'next/server';
 import { createDatabaseService } from 'services/database/databaseFactory';
@@ -15,7 +16,7 @@ const mockDb = {
     create: jest.fn(),
   },
 };
-const mockEmailClient = { sendReactEmail: jest.fn() };
+const mockEmailClient = { sendReactEmail: jest.fn(), checkConfiguration: jest.fn() };
 
 (createDatabaseService as jest.Mock).mockReturnValue(mockDb);
 (createEmailService as jest.Mock).mockReturnValue(mockEmailClient);
@@ -34,6 +35,7 @@ describe('POST /api/auth/magic-link', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDisableEmailVerification = false;
+    mockEmailClient.checkConfiguration.mockResolvedValue({ configured: true, connected: true });
   });
 
   function makeRequest(email?: string) {
@@ -45,7 +47,7 @@ describe('POST /api/auth/magic-link', () => {
   it('returns 400 if email is missing', async () => {
     const req = makeRequest();
     const res = await POST(req);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST);
     const json = await res.json();
     expect(json.error).toMatch(/email is required/i);
   });
@@ -54,7 +56,7 @@ describe('POST /api/auth/magic-link', () => {
     mockDb.user.findByEmail.mockResolvedValue(null);
     const req = makeRequest('notfound@example.com');
     const res = await POST(req);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
     const json = await res.json();
     expect(json.error).toMatch(/user not found/i);
   });
@@ -65,7 +67,7 @@ describe('POST /api/auth/magic-link', () => {
     mockEmailClient.sendReactEmail = jest.fn().mockResolvedValue(undefined);
     const req = makeRequest('test@example.com');
     const res = await POST(req);
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(HTTP_STATUS.OK);
     const json = await res.json();
     expect(json.ok).toBe(true);
     expect(mockDb.user.findByEmail).toHaveBeenCalledWith('test@example.com');
@@ -81,7 +83,7 @@ describe('POST /api/auth/magic-link', () => {
     mockDb.user.findByEmail.mockRejectedValue(new Error('db error'));
     const req = makeRequest('fail@example.com');
     const res = await POST(req);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);
     const json = await res.json();
     expect(json.error).toMatch(/db error/i);
   });
@@ -90,8 +92,17 @@ describe('POST /api/auth/magic-link', () => {
     mockDisableEmailVerification = true;
     const req = { json: async () => ({}) } as unknown as NextRequest;
     const res = await POST(req);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);
     const data = await res.json();
     expect(data.error).toBe('Email feature is disabled');
+  });
+
+  it('returns 500 if email is not configured', async () => {
+    mockEmailClient.checkConfiguration.mockResolvedValue({ configured: false, connected: false });
+    const req = { json: async () => ({}) } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    const data = await res.json();
+    expect(data.error).toBe('Email not configured or connected. Check System Status page');
   });
 });

--- a/application/src/app/api/auth/magic-link/route.test.ts
+++ b/application/src/app/api/auth/magic-link/route.test.ts
@@ -16,25 +16,19 @@ const mockDb = {
     create: jest.fn(),
   },
 };
-const mockEmailClient = { sendReactEmail: jest.fn(), checkConfiguration: jest.fn() };
+const mockEmailClient = {
+  sendReactEmail: jest.fn(),
+  checkConfiguration: jest.fn(),
+  isEmailEnabled: jest.fn(),
+};
 
 (createDatabaseService as jest.Mock).mockReturnValue(mockDb);
 (createEmailService as jest.Mock).mockReturnValue(mockEmailClient);
 
-let mockDisableEmailVerification = false;
-
-jest.mock('settings', () => ({
-  serverConfig: {
-    get disableEmailVerification() {
-      return mockDisableEmailVerification;
-    },
-  },
-}));
-
 describe('POST /api/auth/magic-link', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockDisableEmailVerification = false;
+    mockEmailClient.isEmailEnabled.mockReturnValue(true);
     mockEmailClient.checkConfiguration.mockResolvedValue({ configured: true, connected: true });
   });
 
@@ -89,7 +83,7 @@ describe('POST /api/auth/magic-link', () => {
   });
 
   it('returns 500 if email is missing', async () => {
-    mockDisableEmailVerification = true;
+    mockEmailClient.isEmailEnabled.mockReturnValue(false);
     const req = { json: async () => ({}) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);

--- a/application/src/app/api/auth/magic-link/route.tsx
+++ b/application/src/app/api/auth/magic-link/route.tsx
@@ -28,6 +28,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const emailService = await createEmailService();
+    const emailStatus = await emailService.checkConfiguration();
+
+    if (!emailStatus.configured || !emailStatus.connected) {
+      console.error('Magic link email not configured');
+      return NextResponse.json(
+        { error: 'Email not configured or connected. Check System Status page' },
+        { status: HTTP_STATUS.INTERNAL_SERVER_ERROR }
+      );
+    }
+
     const { email } = await request.json();
     if (!email) {
       return NextResponse.json({ error: 'Email is required' }, { status: HTTP_STATUS.BAD_REQUEST });
@@ -45,7 +56,6 @@ export async function POST(request: NextRequest) {
     // Store the token in the verificationToken table
     await db.verificationToken.create({ identifier: email, token, expires });
 
-    const emailService = await createEmailService();
     const verifyUrl = `${serverConfig.baseURL}/magic-link?token=${token}&email=${encodeURIComponent(email)}`;
     await emailService.sendReactEmail(
       user.email,

--- a/application/src/app/api/auth/magic-link/route.tsx
+++ b/application/src/app/api/auth/magic-link/route.tsx
@@ -21,6 +21,13 @@ import { serverConfig } from 'settings';
  */
 export async function POST(request: NextRequest) {
   try {
+    if (serverConfig.disableEmailVerification) {
+      return NextResponse.json(
+        { error: 'Email feature is disabled' },
+        { status: HTTP_STATUS.INTERNAL_SERVER_ERROR }
+      );
+    }
+
     const { email } = await request.json();
     if (!email) {
       return NextResponse.json({ error: 'Email is required' }, { status: HTTP_STATUS.BAD_REQUEST });

--- a/application/src/app/api/auth/magic-link/route.tsx
+++ b/application/src/app/api/auth/magic-link/route.tsx
@@ -21,14 +21,15 @@ import { serverConfig } from 'settings';
  */
 export async function POST(request: NextRequest) {
   try {
-    if (serverConfig.disableEmailVerification) {
+    const emailService = await createEmailService();
+
+    if (!emailService.isEmailEnabled()) {
       return NextResponse.json(
         { error: 'Email feature is disabled' },
         { status: HTTP_STATUS.INTERNAL_SERVER_ERROR }
       );
     }
 
-    const emailService = await createEmailService();
     const emailStatus = await emailService.checkConfiguration();
 
     if (!emailStatus.configured || !emailStatus.connected) {

--- a/application/src/app/api/forgot-password/route.test.ts
+++ b/application/src/app/api/forgot-password/route.test.ts
@@ -11,23 +11,17 @@ const mockDb = {
   user: { findByEmail: jest.fn() },
   verificationToken: { create: jest.fn() },
 };
-const mockEmailService = { sendReactEmail: jest.fn(), checkConfiguration: jest.fn() };
-
-let mockDisableEmailVerification = false;
-
-jest.mock('settings', () => ({
-  serverConfig: {
-    get disableEmailVerification() {
-      return mockDisableEmailVerification;
-    },
-  },
-}));
+const mockEmailService = {
+  sendReactEmail: jest.fn(),
+  checkConfiguration: jest.fn(),
+  isEmailEnabled: jest.fn(),
+};
 
 beforeEach(() => {
   jest.resetAllMocks();
   (createDatabaseService as jest.Mock).mockResolvedValue(mockDb);
   (createEmailService as jest.Mock).mockResolvedValue(mockEmailService);
-  mockDisableEmailVerification = false;
+  mockEmailService.isEmailEnabled.mockReturnValue(true);
   mockEmailService.checkConfiguration.mockResolvedValue({ configured: true, connected: true });
 });
 
@@ -83,7 +77,7 @@ describe('POST /api/forgot-password', () => {
   });
 
   it('returns 500 if email is missing', async () => {
-    mockDisableEmailVerification = true;
+    mockEmailService.isEmailEnabled.mockReturnValue(false);
     const req = { json: async () => ({}) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);

--- a/application/src/app/api/forgot-password/route.tsx
+++ b/application/src/app/api/forgot-password/route.tsx
@@ -20,6 +20,17 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const emailService = await createEmailService();
+    const emailStatus = await emailService.checkConfiguration();
+
+    if (!emailStatus.configured || !emailStatus.connected) {
+      console.error('Forgot password email not configured');
+      return NextResponse.json(
+        { error: 'Email not configured or connected. Check System Status page' },
+        { status: HTTP_STATUS.INTERNAL_SERVER_ERROR }
+      );
+    }
+
     const { email } = await req.json();
     if (!email) {
       return NextResponse.json({ error: 'Email is required' }, { status: 400 });
@@ -41,7 +52,6 @@ export async function POST(req: NextRequest) {
       expires,
     });
 
-    const emailService = await createEmailService();
     const resetUrl = `${serverConfig.baseURL}/reset-password?token=${token}`;
     await emailService.sendReactEmail(
       email,

--- a/application/src/app/api/forgot-password/route.tsx
+++ b/application/src/app/api/forgot-password/route.tsx
@@ -13,6 +13,13 @@ import { serverConfig } from 'settings';
  */
 export async function POST(req: NextRequest) {
   try {
+    if (serverConfig.disableEmailVerification) {
+      return NextResponse.json(
+        { error: 'Email feature is disabled' },
+        { status: HTTP_STATUS.INTERNAL_SERVER_ERROR }
+      );
+    }
+
     const { email } = await req.json();
     if (!email) {
       return NextResponse.json({ error: 'Email is required' }, { status: 400 });

--- a/application/src/app/api/forgot-password/route.tsx
+++ b/application/src/app/api/forgot-password/route.tsx
@@ -13,14 +13,15 @@ import { serverConfig } from 'settings';
  */
 export async function POST(req: NextRequest) {
   try {
-    if (serverConfig.disableEmailVerification) {
+    const emailService = await createEmailService();
+
+    if (!emailService.isEmailEnabled()) {
       return NextResponse.json(
         { error: 'Email feature is disabled' },
         { status: HTTP_STATUS.INTERNAL_SERVER_ERROR }
       );
     }
 
-    const emailService = await createEmailService();
     const emailStatus = await emailService.checkConfiguration();
 
     if (!emailStatus.configured || !emailStatus.connected) {

--- a/application/src/app/api/password/updatePassword.tsx
+++ b/application/src/app/api/password/updatePassword.tsx
@@ -68,23 +68,26 @@ export const updatePassword = async (
 
     await db.user.update(dbUser.id, dbUser);
 
-    try {
-      const emailService = await createEmailService();
-      await emailService.sendReactEmail(
-        dbUser.email,
-        'Your password has been updated',
-        <InformationEmailTemplate
-          title="Your password has been updated"
-          greetingText="Your password has been updated successfully."
-          infoText="Your password has been updated successfully and you can use it to log into your account."
-          secondInfoText="If you didn't request this change, please contact us immediately."
-        />
-      );
-    } catch (error) {
-      console.error(
-        'Error sending email notification:',
-        error instanceof Error ? `${error.name}: ${error.message}` : error
-      );
+    const emailService = await createEmailService();
+
+    if (emailService.isEmailEnabled()) {
+      try {
+        await emailService.sendReactEmail(
+          dbUser.email,
+          'Your password has been updated',
+          <InformationEmailTemplate
+            title="Your password has been updated"
+            greetingText="Your password has been updated successfully."
+            infoText="Your password has been updated successfully and you can use it to log into your account."
+            secondInfoText="If you didn't request this change, please contact us immediately."
+          />
+        );
+      } catch (error) {
+        console.error(
+          'Error sending email notification:',
+          error instanceof Error ? `${error.name}: ${error.message}` : error
+        );
+      }
     }
 
     return NextResponse.json(

--- a/application/src/app/api/webhook/handleSubscriptionUpdated.tsx
+++ b/application/src/app/api/webhook/handleSubscriptionUpdated.tsx
@@ -53,30 +53,31 @@ export const handleSubscriptionUpdated = async (json: any) => {
 
     const currentPlan = plans.find((p) => p.priceId === priceId);
 
-    const emailClient = await createEmailService();
-
     if (!currentPlan) {
       console.warn(`⚠️ Plan not found for price ID: ${priceId}. Email not sent.`);
       return;
     }
 
-    // Use the new React email component for Resend
-    await emailClient.sendReactEmail(
-      user.email,
-      'Your subscription was updated',
-      <SubscriptionUpdatedEmail
-        plan={{
-          name: currentPlan.name,
-          description: currentPlan.description,
-          amount: currentPlan.amount,
-          interval: currentPlan.interval,
-          features: currentPlan.features,
-          priceId: currentPlan.priceId,
-        }}
-      />
-    );
+    if (!serverConfig.disableEmailVerification) {
+      const emailClient = await createEmailService();
+      // Use the new React email component for Resend
+      await emailClient.sendReactEmail(
+        user.email,
+        'Your subscription was updated',
+        <SubscriptionUpdatedEmail
+          plan={{
+            name: currentPlan.name,
+            description: currentPlan.description,
+            amount: currentPlan.amount,
+            interval: currentPlan.interval,
+            features: currentPlan.features,
+            priceId: currentPlan.priceId,
+          }}
+        />
+      );
+    }
 
-    console.log(`✅ Subscription updated and email sent to ${user.email}`);
+    console.log('✅ Subscription updated');
   } catch (error) {
     console.error('Error sending subscription update email.', error);
   }

--- a/application/src/app/api/webhook/handleSubscriptionUpdated.tsx
+++ b/application/src/app/api/webhook/handleSubscriptionUpdated.tsx
@@ -58,8 +58,9 @@ export const handleSubscriptionUpdated = async (json: any) => {
       return;
     }
 
-    if (!serverConfig.disableEmailVerification) {
-      const emailClient = await createEmailService();
+    const emailClient = await createEmailService();
+
+    if (emailClient.isEmailEnabled()) {
       // Use the new React email component for Resend
       await emailClient.sendReactEmail(
         user.email,

--- a/application/src/lib/auth/auth.ts
+++ b/application/src/lib/auth/auth.ts
@@ -61,7 +61,7 @@ const providers: Provider[] = [
           throw new Error('User not found or password hash is missing');
         }
 
-        if (user.emailVerified === false && !serverConfig.disableEmailVerification) {
+        if (user.emailVerified === false && serverConfig.enableEmailIntegration) {
           throw new Error('Email not verified');
         }
 

--- a/application/src/services/email/email.ts
+++ b/application/src/services/email/email.ts
@@ -15,6 +15,8 @@ export abstract class EmailService implements ConfigurableService {
 
   abstract checkConfiguration(): Promise<ServiceConfigStatus>;
 
+  abstract isEmailEnabled(): boolean;
+
   isRequired(): boolean {
     return true;
   }

--- a/application/src/services/email/resendEmailService.ts
+++ b/application/src/services/email/resendEmailService.ts
@@ -54,6 +54,10 @@ export class ResendEmailService extends EmailService {
     }
   }
 
+  isEmailEnabled(): boolean {
+    return serverConfig.enableEmailIntegration;
+  }
+
   async sendReactEmail(to: string, subject: string, body: React.ReactNode): Promise<void> {
     if (!this.resend) {
       throw new Error('Email client not initialized. Check configuration.');

--- a/application/src/settings.ts
+++ b/application/src/settings.ts
@@ -3,7 +3,7 @@ export interface ServerConfig {
   storageProvider: string;
   emailProvider: string;
   billingProvider: string;
-  disableEmailVerification: boolean;
+  enableEmailIntegration: boolean;
   baseURL?: string;
   Database: {
     url?: string;
@@ -33,7 +33,9 @@ export const serverConfig: ServerConfig = {
   storageProvider: process.env.STORAGE_PROVIDER || 'Spaces',
   emailProvider: process.env.EMAIL_PROVIDER || 'Resend',
   billingProvider: process.env.BILLING_PROVIDER || 'Stripe',
-  disableEmailVerification: process.env.DISABLE_EMAIL_VERIFICATION === 'true',
+  enableEmailIntegration: process.env.ENABLE_EMAIL_INTEGRATION
+    ? process.env.ENABLE_EMAIL_INTEGRATION === 'true'
+    : false,
   baseURL: process.env.BASE_URL,
   Database: {
     url: process.env.DATABASE_URL,


### PR DESCRIPTION
This PR:
- checks for the email feature flag everywhere where email is used
- renames the feature flag to `ENABLE_EMAIL_INTEGRATION`
- adds a method to encapsulate the feature flag check in the email service
- updates tests and templates
- adds a default value of false to the feature flag

![image](https://github.com/user-attachments/assets/0092fcd0-45f6-428d-a2b5-71f852c9644f)

![image](https://github.com/user-attachments/assets/d4678b97-ca97-470f-9a63-a009b2d9e7f6)
